### PR TITLE
add canceling of department invitations

### DIFF
--- a/firecares/firecares_core/ext/invitations/urls.py
+++ b/firecares/firecares_core/ext/invitations/urls.py
@@ -1,5 +1,5 @@
 from django.conf.urls import patterns, url
-from .views import SendJSONDepartmentInvite, AcceptDepartmentInvite
+from .views import SendJSONDepartmentInvite, AcceptDepartmentInvite, CancelInvite
 
 urlpatterns = patterns('',
                        url(r'^send-json-invite/?$',
@@ -7,4 +7,7 @@ urlpatterns = patterns('',
                            name='send-json-invite'),
                        url(r'^accept-invite/(?P<key>\w+)/?$',
                            AcceptDepartmentInvite.as_view(),
-                           name='accept-invite'),)
+                           name='accept-invite'),
+                       url(r'^cancel-invite/(?P<pk>\d+)/?$',
+                           CancelInvite.as_view(),
+                           name='cancel-invite'),)

--- a/firecares/firestation/static/firestation/js/controllers/userInviteController.js
+++ b/firecares/firestation/static/firestation/js/controllers/userInviteController.js
@@ -31,5 +31,22 @@
         }
       });
     };
+
+    $scope.cancelInvitation = function(invitation) {
+      $http.post("/invitations/cancel-invite/" + invitation.id + "/").then(function success(response) {
+        $scope.invitations.splice($scope.invitations.indexOf(invitation), 1);
+        $scope.success = 'Invitation canceled';
+        $scope.error = null;
+        $timeout(function() {
+          $scope.success = null;
+        }, 5000);
+      }, function error(response) {
+        $scope.error = "There was a problem canceling the invitation"
+        $timeout(function() {
+          $scope.error = null;
+        }, 5000);
+      });
+    };
   }
 })();
+

--- a/firecares/firestation/static/firestation/theme/assets/css/style.css
+++ b/firecares/firestation/static/firestation/theme/assets/css/style.css
@@ -11810,6 +11810,9 @@ form[name='boundaryUpload'] a.commit:hover {
 .invitations .form-inline .form-control {
   width: 100%;
 }
+.invitations .delete-invitation {
+  color: red;
+}
 .invitations .panel-group {
   margin-bottom: 1em;
 }

--- a/firecares/firestation/static/firestation/theme/assets/less/firecares.less
+++ b/firecares/firestation/static/firestation/theme/assets/less/firecares.less
@@ -1170,6 +1170,10 @@ form[name='boundaryUpload'] {
     width: 100%;
   }
 
+  .delete-invitation {
+    color: red;
+  }
+
   .panel-group {
     margin-bottom: 1em;
   }

--- a/firecares/firestation/templates/firestation/department_admin_users.html
+++ b/firecares/firestation/templates/firestation/department_admin_users.html
@@ -44,6 +44,7 @@
     var invites = [
       {% for i in invites %}
       {
+        id: {{ i.id }},
         accepted: {{ i.accepted|yesno:"true,false" }},
         email: "{{ i.email }}",
         inviter: "{{ i.inviter.username }}",
@@ -259,6 +260,14 @@
                                     <ul class="list-group list-unstyled">
                                         {% verbatim %}
                                         <li ng-repeat="i in invitations" class="ng-cloak list-group-item">
+                                            <a href=""
+                                                class="btn btn-default btn-xs"
+                                                title="Cancel this invitation"
+                                                ng-click="cancelInvitation(i)"
+                                                ng-show="!i.accepted"
+                                                >
+                                                <i class="fa fa-minus-circle delete-invitation"></i>
+                                            </a>
                                             <span class="pull-right label label-success" ng-if="i.accepted">Invite accepted, username is &quot;{{ i.username }}&quot;</span>
                                             <strong>{{ i.email }}</strong> - sent {{ i.sent }} by {{ i.inviter }}
                                         </li>

--- a/firecares/settings/base.py
+++ b/firecares/settings/base.py
@@ -321,6 +321,7 @@ REGISTRATION_FORM = 'firecares.firecares_core.ext.registration.forms.LimitedRegi
 INVITATIONS_SIGNUP_REDIRECT = 'registration_register'
 INVITATIONS_ALLOW_JSON_INVITES = True
 INVITATIONS_ACCEPT_INVITE_AFTER_SIGNUP = True
+INVITATIONS_GONE_ON_ACCEPT_ERROR = False
 INVITATIONS_ADAPTER = 'firecares.firecares_core.ext.invitations.adapters.DepartmentInvitationsAdapter'
 
 EMAIL_HOST = os.getenv('EMAIL_HOST', 'localhost')


### PR DESCRIPTION
A new setting was added `INVITATIONS_GONE_ON_ACCEPT_ERROR`, with this one after you try to register with the activation link is redirected to the login page with a message of invalid key, otherwise without this activated only returns a request with 410 status, that was not nice.