### PR TITLE
add top margin to avoid cutted axis label on structure hazard graph

### DIFF
--- a/firecares/firestation/static/firestation/js/directives/graphs.js
+++ b/firecares/firestation/static/firestation/js/directives/graphs.js
@@ -462,7 +462,7 @@
           element.find('svg').appear(function() {
             var width = parseInt(attrs.width);
             var height = parseInt(attrs.height);
-            var margins = {top: 0, left: 60, right: 0, bottom: 20};
+            var margins = {top: 5, left: 60, right: 0, bottom: 15};
 
             var data = [{
                 'level': 'Low',


### PR DESCRIPTION
fixes #293 