### PR TITLE
Fix bar chart NaN bug.

### DIFF
--- a/firecares/firestation/static/firestation/js/directives/graphs.js
+++ b/firecares/firestation/static/firestation/js/directives/graphs.js
@@ -1386,7 +1386,7 @@
 
         var latestYear = new Date(barData[barData.length - 1].key).getFullYear();
         var oldestYear = new Date(barData[0].key).getFullYear();
-        var yearSpan = latestYear - oldestYear;
+        var yearSpan = latestYear - oldestYear + 1;
         var years = Math.min(yearSpan, maxYears);
 
         barData = normalizedBarData(barData);


### PR DESCRIPTION
The issue was caused by some bad math where the bar chart was showing one fewer years than it should have been. In the case of departments with only one year of data, it wouldn't show anything.

## Before
<img width="805" alt="Screen Shot 2019-11-22 at 9 06 00 PM" src="https://user-images.githubusercontent.com/3220897/69473690-f4ec2580-0d6b-11ea-8941-67aba2474fff.png">

## After
<img width="806" alt="Screen Shot 2019-11-25 at 1 21 50 PM" src="https://user-images.githubusercontent.com/3220897/69579205-e3329a00-0f86-11ea-9236-949adf10fc7f.png">
