### PR TITLE
Add issuedate range and warngeom spatial filters to weather warnings api

### DIFF
--- a/firecares/firestation/api.py
+++ b/firecares/firestation/api.py
@@ -2,6 +2,7 @@ import json
 import logging
 from .forms import StaffingForm
 from .models import FireStation, Staffing, FireDepartment, ParcelDepartmentHazardLevel, EffectiveFireFightingForceLevel
+from ..utils.tastypie_geodjango import allow_geodjango_filters
 from firecares.weather.models import DepartmentWarnings
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django.core.serializers.json import DjangoJSONEncoder
@@ -392,12 +393,22 @@ class WeatherWarningResource(JSONDefaultModelResourceMixin, ModelResource):
                                               update_permission_code='change_firedepartment',
                                               create_permission_code='change_firedepartment',
                                               delete_permission_code='change_firedepartment')
-        filtering = {'department': ('exact',), 'state': ('exact',), 'id': ('exact',)}
+        filtering = {
+            'department': ('exact',),
+            'state': ('exact',),
+            'id': ('exact',),
+            'issuedate': ('exact', 'range'),
+            'warngeom': ALL,
+        }
         list_allowed_methods = ['get', 'post']
         detail_allowed_methods = ['get']
         cache = SimpleCache(timeout=120)
         serializer = PrettyJSONSerializer()
         always_return_data = True
+
+    def build_filters(self, filters=None, **kwargs):
+        allow_geodjango_filters(self._meta)
+        return super(WeatherWarningResource, self).build_filters(filters)
 
     def get_object_list(self, request):
         return super(WeatherWarningResource, self).get_object_list(request).filter(expiredate__gte=timezone.now())

--- a/firecares/utils/tastypie_geodjango.py
+++ b/firecares/utils/tastypie_geodjango.py
@@ -1,0 +1,39 @@
+
+def allow_geodjango_filters(model_resource_meta):
+    # HACK: Tastypie has a bug where it doesn't recognize geodjango filters. The one exception is the "contains"
+    # filter - but this is just a coincidental overlap with the standard string "contains" filter. So we have to
+    # manually whitelist supported geodjango query terms.
+    model_resource_meta.queryset.query.query_terms.update({
+        'bbcontains',
+        'bboverlaps',
+        'contained',
+        'contains',
+        'contains_properly',
+        'coveredby',
+        'covers',
+        'crosses',
+        'disjoint',
+        'equals',
+        'intersects',
+        'isvalid',
+        'overlaps'
+        'relate',
+        'touches',
+        'within',
+        'left',
+        'right',
+        'overlaps_left',
+        'overlaps_right',
+        'overlaps_above',
+        'overlaps_below',
+        'strictly_above',
+        'strictly_below',
+
+        # Distance lookups are currently unsupported.
+        # https://django-tastypie.readthedocs.io/en/v0.12.2/geodjango.html
+        'distance_gt',
+        'distance_gte',
+        'distance_lt',
+        'distance_lte',
+        'dwithin',
+    })


### PR DESCRIPTION
It should now be possible to filter weather warnings by issuedate range, and by warngeom using any geodjango spatial filter (except distance filters, which tastypie doesn't yet support).

https://www.notion.so/prominentedge/API-to-access-FireCARES-weather-alerts-in-NFORS-1bafbe5268024aa38412f751160221c3#aa4b200672704339a5b67ee856139118

### Example API Request
`GET /api/v1/weather-warning/?issuedate__range=2020-05-23T21:10:00,2020-05-24T21:10:00&warngeom__intersects=POINT(-91.459 31.458)`

**Notes**
- `warngeom` filter value may be any of the following formats: WKT, HEX, WKB, GeoJSON
- `warngeom` spatial filter types can be found here: https://docs.djangoproject.com/en/dev/ref/contrib/gis/geoquerysets/#spatial-lookups