### PR TITLE
Mapbox Deprecation fix

### DIFF
--- a/firecares/firestation/models.py
+++ b/firecares/firestation/models.py
@@ -483,6 +483,8 @@ class FireDepartment(RecentlyUpdatedMixin, Archivable, models.Model):
 
         if marker and geom:
             marker = 'pin-l-embassy+0074D9({geom.x},{geom.y})/'.format(geom=geom)
+        else:
+            marker = ''
             
         return 'https://api.mapbox.com/styles/v1/prominentedge-ipsdi/ckb8cvy2z083c1io0xsvgj01j/static/{marker}' \
             '{geom.x},{geom.y},8/500x300?access_token={access_token}'.format(marker=marker,

--- a/firecares/firestation/models.py
+++ b/firecares/firestation/models.py
@@ -483,9 +483,9 @@ class FireDepartment(RecentlyUpdatedMixin, Archivable, models.Model):
 
         if marker and geom:
             marker = 'pin-l-embassy+0074D9({geom.x},{geom.y})/'.format(geom=geom)
-
-        return 'http://api.tiles.mapbox.com/v4/garnertb.mmlochkh/{marker}' \
-               '{geom.x},{geom.y},8/500x300.jpg?access_token={access_token}'.format(marker=marker,
+            
+        return 'https://api.mapbox.com/styles/v1/prominentedge-ipsdi/ckb8cvy2z083c1io0xsvgj01j/static/{marker}' \
+            '{geom.x},{geom.y},8/500x300?access_token={access_token}'.format(marker=marker,
                                                                                     geom=geom,
                                                                                     access_token=getattr(settings, 'MAPBOX_ACCESS_TOKEN', ''))
 

--- a/firecares/firestation/models.py
+++ b/firecares/firestation/models.py
@@ -485,11 +485,10 @@ class FireDepartment(RecentlyUpdatedMixin, Archivable, models.Model):
             marker = 'pin-l-embassy+0074D9({geom.x},{geom.y})/'.format(geom=geom)
         else:
             marker = ''
-            
         return 'https://api.mapbox.com/styles/v1/prominentedge-ipsdi/ckb8cvy2z083c1io0xsvgj01j/static/{marker}' \
             '{geom.x},{geom.y},8/500x300?access_token={access_token}'.format(marker=marker,
-                                                                                    geom=geom,
-                                                                                    access_token=getattr(settings, 'MAPBOX_ACCESS_TOKEN', ''))
+                                                                             geom=geom,
+                                                                             access_token=getattr(settings, 'MAPBOX_ACCESS_TOKEN', ''))
 
     def set_geometry_from_government_unit(self):
         geom_containers = self.government_unit_objects

--- a/firecares/firestation/tests/test_firestations.py
+++ b/firecares/firestation/tests/test_firestations.py
@@ -537,7 +537,7 @@ class FireStationTests(BaseFirecaresTestcase):
         self.assertEqual(lafd.generate_thumbnail(), 'https://api.mapbox.com/styles/v1/prominentedge-ipsdi/ckb8cvy2z083c1io0xsvgj01j/static/pin-l-embassy+0074D9(-118.411704266,34.1070046338)/-118.411704266,34.1070046338,8/500x300?access_token={0}'.format(settings.MAPBOX_ACCESS_TOKEN))
 
         # ensure the marker is not in the url when marker=False
-        self.assertEqual(lafd.generate_thumbnail(marker=False), 'https://api.mapbox.com/styles/v1/prominentedge-ipsdi/ckb8cvy2z083c1io0xsvgj01j/False-118.411704266,34.1070046338,8/500x300?access_token={0}'.format(settings.MAPBOX_ACCESS_TOKEN))
+        self.assertEqual(lafd.generate_thumbnail(marker=False), 'https://api.mapbox.com/styles/v1/prominentedge-ipsdi/ckb8cvy2z083c1io0xsvgj01j/static/118.411704266,34.1070046338,8/500x300?access_token={0}'.format(settings.MAPBOX_ACCESS_TOKEN))
 
     def test_department_list_view(self):
         """

--- a/firecares/firestation/tests/test_firestations.py
+++ b/firecares/firestation/tests/test_firestations.py
@@ -537,7 +537,7 @@ class FireStationTests(BaseFirecaresTestcase):
         self.assertEqual(lafd.generate_thumbnail(), 'https://api.mapbox.com/styles/v1/prominentedge-ipsdi/ckb8cvy2z083c1io0xsvgj01j/static/pin-l-embassy+0074D9(-118.411704266,34.1070046338)/-118.411704266,34.1070046338,8/500x300?access_token={0}'.format(settings.MAPBOX_ACCESS_TOKEN))
 
         # ensure the marker is not in the url when marker=False
-        self.assertEqual(lafd.generate_thumbnail(marker=False), 'https://api.mapbox.com/styles/v1/prominentedge-ipsdi/ckb8cvy2z083c1io0xsvgj01j/static/118.411704266,34.1070046338,8/500x300?access_token={0}'.format(settings.MAPBOX_ACCESS_TOKEN))
+        self.assertEqual(lafd.generate_thumbnail(marker=False), 'https://api.mapbox.com/styles/v1/prominentedge-ipsdi/ckb8cvy2z083c1io0xsvgj01j/static/-118.411704266,34.1070046338,8/500x300?access_token={0}'.format(settings.MAPBOX_ACCESS_TOKEN))
 
     def test_department_list_view(self):
         """

--- a/firecares/firestation/tests/test_firestations.py
+++ b/firecares/firestation/tests/test_firestations.py
@@ -537,7 +537,6 @@ class FireStationTests(BaseFirecaresTestcase):
         self.assertEqual(lafd.generate_thumbnail(), 'https://api.mapbox.com/styles/v1/prominentedge-ipsdi/ckb8cvy2z083c1io0xsvgj01j/static/pin-l-embassy+0074D9(-118.411704266,34.1070046338)/-118.411704266,34.1070046338,8/500x300?access_token={0}'.format(settings.MAPBOX_ACCESS_TOKEN))
 
         # ensure the marker is not in the url when marker=False
-        self.assertEqual(lafd.generate_thumbnail(marker=False), 'http://api.tiles.mapbox.com/v4/garnertb.mmlochkh/False-118.411704266,34.1070046338,8/500x300.jpg?access_token={0}'.format(settings.MAPBOX_ACCESS_TOKEN))
         self.assertEqual(lafd.generate_thumbnail(marker=False), 'https://api.mapbox.com/styles/v1/prominentedge-ipsdi/ckb8cvy2z083c1io0xsvgj01j/False-118.411704266,34.1070046338,8/500x300?access_token={0}'.format(settings.MAPBOX_ACCESS_TOKEN))
 
     def test_department_list_view(self):

--- a/firecares/firestation/tests/test_firestations.py
+++ b/firecares/firestation/tests/test_firestations.py
@@ -531,7 +531,6 @@ class FireStationTests(BaseFirecaresTestcase):
 
         # ensure a fd with no geometry uses the headquarters address location
         self.assertEqual(lafd.generate_thumbnail(), 'https://api.mapbox.com/styles/v1/prominentedge-ipsdi/ckb8cvy2z083c1io0xsvgj01j/static/pin-l-embassy+0074D9(-118.421704266,34.0970046338)/-118.421704266,34.0970046338,8/500x300?access_token={0}'.format(settings.MAPBOX_ACCESS_TOKEN))
-        
         # ensure a fd with a geometry uses the centroid of the geometry
         lafd.geom = MultiPolygon([lafd_poly])
         self.assertEqual(lafd.generate_thumbnail(), 'https://api.mapbox.com/styles/v1/prominentedge-ipsdi/ckb8cvy2z083c1io0xsvgj01j/static/pin-l-embassy+0074D9(-118.411704266,34.1070046338)/-118.411704266,34.1070046338,8/500x300?access_token={0}'.format(settings.MAPBOX_ACCESS_TOKEN))

--- a/firecares/firestation/tests/test_firestations.py
+++ b/firecares/firestation/tests/test_firestations.py
@@ -530,14 +530,15 @@ class FireStationTests(BaseFirecaresTestcase):
         lafd.save()
 
         # ensure a fd with no geometry uses the headquarters address location
-        self.assertEqual(lafd.generate_thumbnail(), 'http://api.tiles.mapbox.com/v4/garnertb.mmlochkh/pin-l-embassy+0074D9(-118.421704266,34.0970046338)/-118.421704266,34.0970046338,8/500x300.jpg?access_token={0}'.format(settings.MAPBOX_ACCESS_TOKEN))
-
+        self.assertEqual(lafd.generate_thumbnail(), 'https://api.mapbox.com/styles/v1/prominentedge-ipsdi/ckb8cvy2z083c1io0xsvgj01j/static/pin-l-embassy+0074D9(-118.421704266,34.0970046338)/-118.421704266,34.0970046338,8/500x300?access_token={0}'.format(settings.MAPBOX_ACCESS_TOKEN))
+        
         # ensure a fd with a geometry uses the centroid of the geometry
         lafd.geom = MultiPolygon([lafd_poly])
-        self.assertEqual(lafd.generate_thumbnail(), 'http://api.tiles.mapbox.com/v4/garnertb.mmlochkh/pin-l-embassy+0074D9(-118.411704266,34.1070046338)/-118.411704266,34.1070046338,8/500x300.jpg?access_token={0}'.format(settings.MAPBOX_ACCESS_TOKEN))
+        self.assertEqual(lafd.generate_thumbnail(), 'https://api.mapbox.com/styles/v1/prominentedge-ipsdi/ckb8cvy2z083c1io0xsvgj01j/static/pin-l-embassy+0074D9(-118.411704266,34.1070046338)/-118.411704266,34.1070046338,8/500x300?access_token={0}'.format(settings.MAPBOX_ACCESS_TOKEN))
 
         # ensure the marker is not in the url when marker=False
         self.assertEqual(lafd.generate_thumbnail(marker=False), 'http://api.tiles.mapbox.com/v4/garnertb.mmlochkh/False-118.411704266,34.1070046338,8/500x300.jpg?access_token={0}'.format(settings.MAPBOX_ACCESS_TOKEN))
+        self.assertEqual(lafd.generate_thumbnail(marker=False), 'https://api.mapbox.com/styles/v1/prominentedge-ipsdi/ckb8cvy2z083c1io0xsvgj01j/False-118.411704266,34.1070046338,8/500x300?access_token={0}'.format(settings.MAPBOX_ACCESS_TOKEN))
 
     def test_department_list_view(self):
         """


### PR DESCRIPTION
Changes Mapbox static image to use style from Mapbox studio instead of deprecated Mapbox Studio Classic.